### PR TITLE
Add cluster type to RedisType

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mskcc.oncokb.meta</groupId>
     <artifactId>oncokb-meta</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.3-SNAPSHOT</version>
     <name>OncoKB Meta</name>
     <description>Models that can be shared with other projects</description>
     <properties>

--- a/src/main/java/org/mskcc/oncokb/meta/enumeration/RedisType.java
+++ b/src/main/java/org/mskcc/oncokb/meta/enumeration/RedisType.java
@@ -2,7 +2,8 @@ package org.mskcc.oncokb.meta.enumeration;
 
 public enum RedisType {
     SINGLE("single"),
-    SENTINEL("sentinel");
+    SENTINEL("sentinel"),
+    CLUSTER("cluster");
 
     private final String type;
 


### PR DESCRIPTION
We want to support cluster type, so that we can test the performance of oncokb-core-beta. 
We are using Jitpack to package oncokb-meta, so the version of oncokb-meta needs to be changed.